### PR TITLE
Fix compile issue on MacOSX

### DIFF
--- a/src/ip.c
+++ b/src/ip.c
@@ -25,9 +25,14 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
-#ifndef __FreeBSD__
-#include <error.h>
-#endif /* __FreeBSD__ */
+// #if !defined(__FreeBSD__) && !defined(__APPLE__)
+#ifndef __FreeBSD__ 
+  #ifdef __APPLE__
+    #include <mach/error.h>
+  #else
+    #include <sys/error.h> 
+  #endif
+#endif
 
 // private functions
 


### PR DESCRIPTION
``` C
// #if !defined(__FreeBSD__) && !defined(__APPLE__)
#ifndef __FreeBSD__ 
  #ifdef __APPLE__
    #include <mach/error.h>
  #else
    #include <sys/error.h> 
  #endif
#endif
```

Not 100% sure if macosx needs error.h but it works.
