### PR TITLE
Bsd

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,4 @@
 #Makefile
-CC=gcc
 
 OCFLAGS=-g -O3 -Wall -Wextra
 DCFLAGS=-g

--- a/src/cxtracker.c
+++ b/src/cxtracker.c
@@ -210,7 +210,9 @@ void got_packet (u_char *useless,const struct pcap_pkthdr *pheader, const u_char
    if ( intr_flag != 0 ) { check_interupt(); }
    inpacket = 1;
 
-   tstamp = pheader->ts;
+   tstamp.tv_sec = (long) pheader->ts.tv_sec;
+   tstamp.tv_usec = (long) pheader->ts.tv_usec;
+   /* tstamp = pheader->ts; */
 
    /* are we dumping */
    if (mode & MODE_DUMP) {
@@ -624,10 +626,10 @@ void cxtbuffer_write () {
 
    if (mode == MODE_FILE) {
        bname = strdup(basename(read_file));
-       sprintf(cxtfname, "%sstats.%s.%ld", dpath, bname, tstamp.tv_sec);
+       snprintf(cxtfname, sizeof(cxtfname), "%sstats.%s.%ld", dpath, bname, (long) tstamp.tv_sec);
        free(bname);
    } else {
-       sprintf(cxtfname, "%sstats.%s.%ld", dpath, dev, tstamp.tv_sec);
+       snprintf(cxtfname, sizeof(cxtfname), "%sstats.%s.%ld", dpath, dev, (long) tstamp.tv_sec);
    }
    cxtFile = fopen(cxtfname, "w");
 

--- a/src/cxtracker.c
+++ b/src/cxtracker.c
@@ -210,9 +210,10 @@ void got_packet (u_char *useless,const struct pcap_pkthdr *pheader, const u_char
    if ( intr_flag != 0 ) { check_interupt(); }
    inpacket = 1;
 
+   /* on OpenBSD the ts struct of the bpf header has a different definition
+    * than a timeval so assigning to timeval members individually */
    tstamp.tv_sec = (long) pheader->ts.tv_sec;
    tstamp.tv_usec = (long) pheader->ts.tv_usec;
-   /* tstamp = pheader->ts; */
 
    /* are we dumping */
    if (mode & MODE_DUMP) {

--- a/src/cxtracker.c
+++ b/src/cxtracker.c
@@ -774,7 +774,7 @@ int dump_file_open()
 
 	}
 
-   if ( strcmp(dpath, "./") == 0 )
+   if ( strcmp(dpath, "./") != 0 )
    {
 	if(datedir)
 	{

--- a/src/cxtracker.c
+++ b/src/cxtracker.c
@@ -379,7 +379,6 @@ void got_packet (u_char *useless,const struct pcap_pkthdr *pheader, const u_char
    /* } */
 }
 
-inline
 int cx_track(ip_t *ip_src, uint16_t src_port,ip_t *ip_dst, uint16_t dst_port,
                uint8_t ip_proto, uint32_t p_bytes, uint8_t tcpflags,struct timeval tstamp, int af) {
 
@@ -775,7 +774,7 @@ int dump_file_open()
 
 	}
 
-   if ( dpath != NULL )
+   if ( strcmp(dpath, "./") == 0 )
    {
 	if(datedir)
 	{
@@ -1039,7 +1038,7 @@ int daemonize() {
 }
 
 static int go_daemon() {
-    return daemonize(NULL);
+    return daemonize();
 }
 
 static void banner() {

--- a/src/cxtracker.h
+++ b/src/cxtracker.h
@@ -24,11 +24,8 @@
 #define __CXTRACKER_H__
 
 /*  I N C L U D E S  **********************************************************/
-#include "ip.h"
-
-#ifdef __FreeBSD__
 #include <sys/types.h>
-#endif /* __FreeBSD__ */
+#include "ip.h"
 
 /*  D E F I N E S  ************************************************************/
 #define VERSION                       "0.9.8.5"

--- a/src/format.c
+++ b/src/format.c
@@ -464,7 +464,7 @@ void format_write(FILE *fd, const connection *cxt)
 
 void format_write_cxid(FILE *fd, const connection *cxt, const char *prefix)
 {
-    fprintf(fd, "%s%ld%09ju", prefix, cxt->start_time.tv_sec, cxt->cxid);
+    fprintf(fd, "%s%ld%09ju", prefix, (long) cxt->start_time.tv_sec, cxt->cxid);
 }
 
 void format_write_time_start(FILE *fd, const connection *cxt, const char *prefix)
@@ -485,12 +485,12 @@ void format_write_utime_start(FILE *fd, const connection *cxt, const char *prefi
 
 void format_write_unixtime_start(FILE *fd, const connection *cxt, const char *prefix)
 {
-    fprintf(fd, "%s%lu", prefix, cxt->start_time.tv_sec);
+    fprintf(fd, "%s%lu", prefix, (long) cxt->start_time.tv_sec);
 }
 
 void format_write_unixutime_start(FILE *fd, const connection *cxt, const char *prefix)
 {
-    fprintf(fd, "%s%lu.%lu", prefix, cxt->start_time.tv_sec, cxt->start_time.tv_usec);
+    fprintf(fd, "%s%lu.%lu", prefix, (long) cxt->start_time.tv_sec, (long) cxt->start_time.tv_usec);
 }
 
 void format_write_time_end(FILE *fd, const connection *cxt, const char *prefix)
@@ -511,17 +511,17 @@ void format_write_utime_end(FILE *fd, const connection *cxt, const char *prefix)
 
 void format_write_unixtime_end(FILE *fd, const connection *cxt, const char *prefix)
 {
-    fprintf(fd, "%s%lu", prefix, cxt->last_pkt_time.tv_sec);
+    fprintf(fd, "%s%lu", prefix, (long) cxt->last_pkt_time.tv_sec);
 }
 
 void format_write_unixutime_end(FILE *fd, const connection *cxt, const char *prefix)
 {
-    fprintf(fd, "%s%lu.%lu", prefix, cxt->last_pkt_time.tv_sec, cxt->last_pkt_time.tv_usec);
+    fprintf(fd, "%s%lu.%lu", prefix, (long) cxt->last_pkt_time.tv_sec, (long) cxt->last_pkt_time.tv_usec);
 }
 
 void format_write_time_duration(FILE *fd, const connection *cxt, const char *prefix)
 {
-    fprintf(fd, "%s%ld", prefix, cxt->last_pkt_time.tv_sec - cxt->start_time.tv_sec);
+    fprintf(fd, "%s%ld", prefix, (long) (cxt->last_pkt_time.tv_sec - cxt->start_time.tv_sec));
 }
 
 void format_write_ip_family(FILE *fd, const connection *cxt, const char *prefix)

--- a/src/ip.c
+++ b/src/ip.c
@@ -25,13 +25,12 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
-#ifndef __FreeBSD__ 
-  #ifdef __APPLE__
+#ifdef __APPLE__
     #include <mach/error.h>
-  #else
+#endif /* __APPLE__ */
+#ifdef linux
     #include <error.h> 
-  #endif /* __APPLE__ */
-#endif /* __FreeBSD__ */
+#endif /* linux */
 
 // private functions
 

--- a/src/ip.h
+++ b/src/ip.h
@@ -25,8 +25,8 @@
 #include <stdlib.h>
 #include <netinet/in.h>
 #include <netdb.h>
-
-#ifdef __FreeBSD__
+#include <sys/param.h>
+#ifdef BSD
 #include <sys/socket.h>
 #endif /* __FreeBSD__ */
 

--- a/src/ip.h
+++ b/src/ip.h
@@ -25,10 +25,13 @@
 #include <stdlib.h>
 #include <netinet/in.h>
 #include <netdb.h>
+
+#if (defined(__unix__) || defined(unix)) && !defined(USG)
 #include <sys/param.h>
+#endif
 #ifdef BSD
 #include <sys/socket.h>
-#endif /* __FreeBSD__ */
+#endif /* BSD */
 
 #define IP_ADDRMAX       NI_MAXHOST
 


### PR DESCRIPTION
Compile on OpenBSD 6.1, FreeBSD 11.0 with clang compiler, Linux (tested on Ubuntu 14.04) and remove compiler warnings on these platforms.  The main change for OpenBSD was line 213 in src/cxtracker.c